### PR TITLE
Use correct endpoint for getting the auth URL

### DIFF
--- a/Sources/Pocket/Pocket+Authentication.swift
+++ b/Sources/Pocket/Pocket+Authentication.swift
@@ -13,7 +13,7 @@ import Foundation
 extension Pocket {
 
     public static let requestTokenUrl = URL(string: "https://getpocket.com/v3/oauth/request")!
-    public static let authorizeUrl = URL(string: "https://getpocket.com/v3/auth/authorize")!
+    public static let authorizeUrl = URL(string: "https://getpocket.com/auth/authorize")!
     public static let accessTokenUrl = URL(string: "https://getpocket.com/v3/oauth/authorize")!
 
     private struct ObtainRequestTokenResponse: Decodable {

--- a/Sources/Pocket/Pocket+Authentication.swift
+++ b/Sources/Pocket/Pocket+Authentication.swift
@@ -13,7 +13,8 @@ import Foundation
 extension Pocket {
 
     public static let requestTokenUrl = URL(string: "https://getpocket.com/v3/oauth/request")!
-    public static let authorizeUrl = URL(string: "https://getpocket.com/v3/oauth/authorize")!
+    public static let authorizeUrl = URL(string: "https://getpocket.com/v3/auth/authorize")!
+    public static let accessTokenUrl = URL(string: "https://getpocket.com/v3/oauth/authorize")!
 
     private struct ObtainRequestTokenResponse: Decodable {
 
@@ -69,7 +70,7 @@ extension Pocket {
             "code": requestToken
         ]
 
-        let response: ObtainAccessTokenResponse = try await request(url: Pocket.authorizeUrl, jsonData: data)
+        let response: ObtainAccessTokenResponse = try await request(url: Pocket.accessTokenUrl, jsonData: data)
         accessToken = response.accessToken
         username = response.username
         return response.accessToken


### PR DESCRIPTION
`buildAuthorizationUrl` makes a request to `/v3/oauth/authorize`, when it should instead be making a request to `/v3/auth/authorize`. The first endpoint is used for access tokens and takes POST params, while the second is for the user authorizing your app and takes GET params.

See https://getpocket.com/developer/docs/authentication.